### PR TITLE
Prevent Tranfser Error on Large Data Files

### DIFF
--- a/Tftp.Net/Transfer/States/Receiving.cs
+++ b/Tftp.Net/Transfer/States/Receiving.cs
@@ -27,7 +27,13 @@ namespace Tftp.Net.Transfer.States
                 }
                 else
                 {
-                    nextBlockNumber++;
+                    int tempBlockNumber = (int)nextBlockNumber + 1;
+                    if (tempBlockNumber > (int)UInt16.MaxValue)
+                    {
+                        // On wrap-around of block number, restart at the first valid data block number (1).
+                        tempBlockNumber = 1;
+                    }
+                    nextBlockNumber = (ushort)tempBlockNumber;
                     bytesReceived += command.Bytes.Length;
                     Context.RaiseOnProgress(bytesReceived);
                 }

--- a/Tftp.Net/Transfer/States/Sending.cs
+++ b/Tftp.Net/Transfer/States/Sending.cs
@@ -39,7 +39,13 @@ namespace Tftp.Net.Transfer.States
             }
             else
             {
-                SendNextPacket((ushort)(lastBlockNumber + 1));
+                int nextBlockNumber = (int)lastBlockNumber + 1;
+                if (nextBlockNumber > (int)UInt16.MaxValue)
+                {
+                    // On wrap-around of block number, restart at the first valid data block number (1).
+                    nextBlockNumber = 1;
+                }
+                SendNextPacket((ushort)nextBlockNumber);
             }
         }
 


### PR DESCRIPTION
Update to prevent attempt to use data block number zero on transferring large data files (or small block sizes). Per the TFTP spec, the first valid data block number is 1.